### PR TITLE
fix: API 조립 구조 정리 및 todos 스키마 검증 강화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,12 @@ Django 템플릿 + HTMX로 동적 콘텐츠 처리. `templates/index.html`을 �
 - API 엔드포인트 개발 시 반드시 **django-ninja**를 사용한다 (DRF 사용 금지).
   - 앱의 `api.py`에서 `Router`로 엔드포인트 정의 → `yorisa/api.py`의 단일 `NinjaAPI` 인스턴스에 마운트
   - 요청/응답 검증은 `ninja.Schema` (Pydantic 기반) 사용
-  - PATCH용 스키마는 모든 필드를 `Optional`로 선언하고 `exclude_unset=True`로 처리
+  - PATCH용 스키마는 모든 필드를 **선택 입력**(기본값 보유)으로 선언하고 핸들러에서 `exclude_unset=True`로 처리
+    - "선택 입력"은 *필수가 아님*을 뜻하며 **`| None`(nullable)과 다르다.**
+    - `| None`은 **모델 컬럼이 `null=True`인 필드에만** 붙인다. 그래야 `{"field": null}`이 "값 해제"로 처리된다.
+    - NOT NULL 컬럼에 `| None`을 붙이면 안 된다. `exclude_unset=True`는 *보내지 않은* 필드만 거를 뿐 *명시적으로 보낸 null*은 통과시켜 DB NOT NULL 위반이 된다. 대신 모델 기본값과 같은 유효한 값을 기본값으로 준다.
+  - 요청 스키마의 제약은 모델 제약을 그대로 반영한다. 길이는 `Annotated[str, StringConstraints(...)]`, choices는 `models.TextChoices`를 필드 타입으로 직접 사용한다 (`api.py`가 `full_clean()`을 호출하지 않으므로 스키마가 유일한 검증 지점이다).
+  - 응답 스키마의 choices 필드는 `str`로 둔다. DB에 남아 있을 수 있는 규격 밖 값 때문에 조회가 500이 되는 것을 막기 위함이다.
 - commit(커밋) 관련 요청이 오면 `commit` SKILL(`.claude/skills/commit/SKILL.md`)의 내용을 우선 참고하여 진행한다.
 
 ## 설정

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ uv run mypy .                        # 타입 검사
 
 ## 아키텍처
 
-- **yorisa/** — Django 프로젝트 설정 (settings, 루트 URL 설정)
+- **yorisa/** — Django 프로젝트 설정 (settings, 루트 URL 설정, API 조립 `api.py`)
 - **accounts/** — 커스텀 유저 모델 (`Member`, `AbstractUser` 상속). `AUTH_USER_MODEL = "accounts.Member"`
 - **todos/** — 핵심 앱: `Todo`, `Category` 모델 및 django-ninja REST API
 - **templates/** — Django 템플릿 + HTMX. `base.html`에서 HTMX CDN 로드
@@ -35,10 +35,11 @@ uv run mypy .                        # 타입 검사
 ### API 계층
 
 API는 **django-ninja**를 사용한다 (DRF 아님). 구조:
-- `todos/urls.py`에서 `NinjaAPI` 인스턴스 생성 후 라우터 마운트
-- `todos/views.py`에서 `@router.get/post/put/patch/delete`로 엔드포인트 정의
-- `todos/schemas.py`에서 Pydantic 스타일 `Schema` 클래스로 요청/응답 검증
-- 루트 URL 설정(`yorisa/urls.py`)에서 `/api/` 경로에 마운트
+- 각 앱의 `api.py`에서 `Router`를 만들고 `@router.get/post/put/patch/delete`로 엔드포인트를 정의한다. 앱은 `Router`만 export하며 `NinjaAPI` 인스턴스를 만들지 않는다.
+- 각 앱의 `schemas.py`에서 Pydantic 스타일 `Schema` 클래스로 요청/응답을 검증한다.
+- `yorisa/api.py`에서 `NinjaAPI` 인스턴스를 **하나만** 만들고 모든 앱 Router를 마운트한다 (`/auth/`, `/accounts/`, `/todos/` 순).
+- 루트 URL 설정(`yorisa/urls.py`)에서 `path("api/", api.urls)`로 `/api/`에 연결한다.
+- 앱 모듈은 `yorisa.api`를 import하지 않는다 (순환 import 방지). 새 앱의 API는 `<app>/api.py`에 Router를 만들고 `yorisa/api.py`에 한 줄 마운트한다.
 
 ### 프론트엔드
 
@@ -49,7 +50,7 @@ Django 템플릿 + HTMX로 동적 콘텐츠 처리. `templates/index.html`을 �
 ## 개발 규칙
 
 - API 엔드포인트 개발 시 반드시 **django-ninja**를 사용한다 (DRF 사용 금지).
-  - `Router`로 엔드포인트 정의 → `NinjaAPI` 인스턴스에 마운트
+  - 앱의 `api.py`에서 `Router`로 엔드포인트 정의 → `yorisa/api.py`의 단일 `NinjaAPI` 인스턴스에 마운트
   - 요청/응답 검증은 `ninja.Schema` (Pydantic 기반) 사용
   - PATCH용 스키마는 모든 필드를 `Optional`로 선언하고 `exclude_unset=True`로 처리
 - commit(커밋) 관련 요청이 오면 `commit` SKILL(`.claude/skills/commit/SKILL.md`)의 내용을 우선 참고하여 진행한다.

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,21 +73,35 @@ PyJWT 기반 회원가입/로그인 API. 서명 알고리즘은 HS256, 서명 �
 | 클래스 | 용도 |
 |--------|------|
 | `TodoCreate` | 생성(POST) / 전체 수정(PUT) 요청 바디 |
-| `TodoPatch` | 부분 수정(PATCH) 요청 바디 — 모든 필드 Optional |
-| `TodoList` | 응답 (id, title, description, status, category, member) |
+| `TodoPatch` | 부분 수정(PATCH) 요청 바디 — 모든 필드 선택 입력 |
+| `TodoList` | 응답 (id, title, description, status, category_id, member_id, due_date) |
+
+#### 필드
+
+| 필드 | 타입 | 제약 | `null` 허용 |
+|------|------|------|-------------|
+| `title` | string | 1~200자, 앞뒤 공백 제거 후 검사 | 불가 |
+| `description` | string | 제한 없음 | 불가 |
+| `status` | enum | `todo` / `in_progress` / `done` | 불가 |
+| `category` | integer | 본인 소유 카테고리만 (아니면 404) | 허용 (값 해제) |
+| `due_date` | string(date) | `YYYY-MM-DD` | 허용 (값 해제) |
+
+PATCH에서 `category`·`due_date`에 `null`을 보내면 값이 해제된다. 나머지 필드에 `null`을 보내면 422다. 제약 위반은 모두 422를 반환한다.
 
 ### 엔드포인트
 
 | 메서드 | 경로 | 응답 코드 | 설명 |
 |--------|------|-----------|------|
-| GET | `/` | 200 | 목록 조회 (`?status=`로 필터 가능) |
-| POST | `/` | 201 | 생성 |
+| GET | `/` | 200 / 422 | 목록 조회 (`?status=`로 필터. 규격 밖 값은 422) |
+| POST | `/` | 201 / 422 | 생성 |
 | GET | `/{todo_id}/` | 200 | 상세 조회 |
-| PUT | `/{todo_id}/` | 200 | 전체 수정 |
-| PATCH | `/{todo_id}/` | 200 | 부분 수정 |
+| PUT | `/{todo_id}/` | 200 / 422 | 전체 수정 |
+| PATCH | `/{todo_id}/` | 200 / 422 | 부분 수정 |
 | DELETE | `/{todo_id}/` | 204 | 삭제 |
 
 category 지정 시 해당 카테고리도 `member=request.user` 소유 여부를 검증한다.
+
+**PUT은 전체 교체다.** 요청에서 생략한 필드는 모델 기본값으로 초기화된다 (`status`는 `todo`, `category`와 `due_date`는 `null`). 일부 필드만 바꾸려면 PATCH를 사용한다.
 
 ### Categories
 
@@ -97,18 +111,18 @@ category 지정 시 해당 카테고리도 `member=request.user` 소유 여부�
 
 | 클래스 | 용도 |
 |--------|------|
-| `CategoryCreate` | 생성(POST) 요청 바디 (name) |
-| `CategoryPatch` | 부분 수정(PATCH) 요청 바디 — name Optional |
-| `CategoryOut` | 응답 (id, name, member) |
+| `CategoryCreate` | 생성(POST) 요청 바디 (name — 1~50자, 앞뒤 공백 제거) |
+| `CategoryPatch` | 부분 수정(PATCH) 요청 바디 — name 선택 입력, `null` 불가 |
+| `CategoryOut` | 응답 (id, name, member_id) |
 
 #### 엔드포인트
 
 | 메서드 | 경로 | 응답 코드 | 설명 |
 |--------|------|-----------|------|
 | GET | `/` | 200 | 목록 조회 |
-| POST | `/` | 201 / 400 | 생성. 같은 회원 내 이름 중복 시 400 |
+| POST | `/` | 201 / 400 / 422 | 생성. 같은 회원 내 이름 중복 시 400, 길이 위반 시 422 |
 | GET | `/{category_id}/` | 200 | 상세 조회 |
-| PATCH | `/{category_id}/` | 200 / 400 | 부분 수정. 이름 중복 시 400 |
+| PATCH | `/{category_id}/` | 200 / 400 / 422 | 부분 수정. 이름 중복 시 400, 길이 위반 시 422 |
 | DELETE | `/{category_id}/` | 204 | 삭제 |
 
 `member`가 다른 카테고리에 접근하면 404를 반환한다(존재 여부를 노출하지 않음). 이름 유일성은 회원 단위로 검증한다(`unique_together = [member, name]`).

--- a/todos/CLAUDE.md
+++ b/todos/CLAUDE.md
@@ -15,6 +15,7 @@
 - `title` (CharField, max=200) — 제목
 - `description` (TextField, blank=True) — 설명
 - `status` (CharField, default="todo") — 상태값: `Todo.Status` TextChoices
+- `due_date` (DateField, null=True, blank=True) — 기한일 (선택)
 
 #### Todo.Status
 | 값            | 레이블  |
@@ -30,7 +31,7 @@
 ## 파일 구조
 
 - `models.py` — Category, Todo 모델
-- `schemas.py` — TodoCreate(생성/전체수정), TodoPatch(부분수정), TodoList(응답) 스키마
+- `schemas.py` — TodoCreate(생성/전체수정), TodoPatch(부분수정 — nullable 컬럼만 `| None`), TodoList(응답), CategoryCreate/CategoryPatch/CategoryOut 스키마. 길이·choices 제약은 모델과 1:1로 대응한다.
 - `views.py` — 템플릿 렌더링 뷰 함수 (HTMX 파셜 포함)
 - `api.py` — django-ninja `Router`로 Todo/Category CRUD 엔드포인트 정의 (`router`만 export). NinjaAPI 인스턴스 생성 및 마운트는 `yorisa/api.py`가 담당한다.
 - `urls.py` — 템플릿 뷰용 urlpatterns

--- a/todos/CLAUDE.md
+++ b/todos/CLAUDE.md
@@ -32,7 +32,7 @@
 - `models.py` — Category, Todo 모델
 - `schemas.py` — TodoCreate(생성/전체수정), TodoPatch(부분수정), TodoList(응답) 스키마
 - `views.py` — 템플릿 렌더링 뷰 함수 (HTMX 파셜 포함)
-- `api.py` — django-ninja Router로 CRUD 엔드포인트 정의, NinjaAPI 인스턴스 생성 및 router 마운트
+- `api.py` — django-ninja `Router`로 Todo/Category CRUD 엔드포인트 정의 (`router`만 export). NinjaAPI 인스턴스 생성 및 마운트는 `yorisa/api.py`가 담당한다.
 - `urls.py` — 템플릿 뷰용 urlpatterns
 
 ## 테스트

--- a/todos/api.py
+++ b/todos/api.py
@@ -59,7 +59,7 @@ def category_delete_api(request, category_id: int):
 
 
 @router.get("/", response=list[TodoList])
-def todo_list_api(request, status: str | None = None):
+def todo_list_api(request, status: Todo.Status | None = None):
     todos = Todo.objects.filter(member=request.user)
     if status:
         todos = todos.filter(status=status)

--- a/todos/api.py
+++ b/todos/api.py
@@ -1,9 +1,8 @@
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
-from ninja import NinjaAPI, Router
+from ninja import Router
 from ninja.security import django_auth
 
-from accounts.api import profile_router, router as auth_router
 from todos.models import Category, Todo
 from todos.schemas import (
     CategoryCreate,
@@ -119,9 +118,3 @@ def todo_delete_api(request, todo_id: int):
     todo = get_object_or_404(Todo, id=todo_id, member=request.user)
     todo.delete()
     return 204, None
-
-
-api = NinjaAPI()
-api.add_router("/todos/", router)
-api.add_router("/auth/", auth_router)
-api.add_router("/accounts/", profile_router)

--- a/todos/schemas.py
+++ b/todos/schemas.py
@@ -1,12 +1,47 @@
+"""todos API 요청/응답 스키마.
+
+설계 원칙
+- 요청 스키마의 제약(길이·choices)은 `todos.models`의 모델 제약을 그대로 반영한다.
+  `api.py`는 `full_clean()`을 호출하지 않으므로, 스키마가 유일한 검증 지점이다.
+- PATCH 스키마는 모든 필드에 기본값을 주어 "필수 아님"으로 만들고,
+  핸들러에서 `payload.dict(exclude_unset=True)`로 전송된 필드만 반영한다.
+- `| None`(nullable)은 **모델 컬럼이 `null=True`인 필드에만** 붙인다.
+  `exclude_unset=True`는 "보내지 않은 필드"만 걸러낼 뿐 "명시적으로 보낸 null"은
+  걸러내지 못하므로, NOT NULL 컬럼에 `| None`을 붙이면 `{"title": null}` 같은
+  요청이 DB NOT NULL 위반으로 이어진다.
+"""
+
+from datetime import date
+from typing import Annotated
+
 from ninja import Schema
+from pydantic import StringConstraints
+
+from todos.models import Todo
+
+# 모델 제약과 1:1로 대응하는 문자열 타입 별칭.
+# strip_whitespace는 템플릿 뷰(`views.py`의 `.strip()`)와 동작을 맞추기 위한 것으로,
+# 앞뒤 공백 제거 후 길이를 검사한다(공백만 있는 입력은 min_length 위반으로 422).
+CategoryName = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=50)
+]
+TodoTitle = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=200)
+]
+
+# `Todo.Status.TODO`를 직접 참조하면 django-stubs가 없는 환경의 mypy가 TextChoices 멤버를
+# `tuple[str, str]`로 오인해 assignment 오류를 낸다. 값으로 생성하면 런타임 결과는 동일하다
+# (`Todo.Status("todo") is Todo.Status.TODO`).
+DEFAULT_STATUS = Todo.Status("todo")
 
 
 class CategoryCreate(Schema):
-    name: str
+    name: CategoryName
 
 
 class CategoryPatch(Schema):
-    name: str | None = None
+    # 기본값은 exclude_unset=True 때문에 사용되지 않는 자리표시자다.
+    name: CategoryName = ""
 
 
 class CategoryOut(Schema):
@@ -16,23 +51,41 @@ class CategoryOut(Schema):
 
 
 class TodoCreate(Schema):
-    title: str
+    """생성(POST) / 전체 수정(PUT) 요청 바디."""
+
+    title: TodoTitle
     description: str = ""
-    status: str = "todo"
+    status: Todo.Status = DEFAULT_STATUS
     category: int | None = None
+    due_date: date | None = None
 
 
 class TodoPatch(Schema):
-    title: str | None = None
-    description: str | None = None
-    status: str | None = None
+    """부분 수정(PATCH) 요청 바디.
+
+    모든 필드가 선택 입력이다. `category`와 `due_date`만 모델이 `null=True`이므로
+    명시적 null을 "값 해제"로 받아들이고, 나머지는 null을 422로 거절한다.
+    """
+
+    title: TodoTitle = ""
+    description: str = ""
+    status: Todo.Status = DEFAULT_STATUS
     category: int | None = None
+    due_date: date | None = None
 
 
 class TodoList(Schema):
+    """응답 스키마.
+
+    `status`는 의도적으로 `str`로 둔다. 이번 수정 이전에 API로 저장된
+    choices 밖 값이 DB에 남아 있으면, enum으로 선언할 경우 응답 검증 단계에서
+    ValidationError가 발생해 조회 자체가 500이 된다(수신은 관대하게).
+    """
+
     id: int
     title: str
     description: str
     status: str
     category_id: int | None
     member_id: int | None
+    due_date: date | None

--- a/todos/tests/test_category_api.py
+++ b/todos/tests/test_category_api.py
@@ -57,6 +57,27 @@ class CategoryCreateTest(TestCase):
         )
         self.assertEqual(response.status_code, 201)
 
+    def test_create_empty_name(self):
+        response = client.post("/categories/", json={"name": ""}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_null_name(self):
+        response = client.post("/categories/", json={"name": None}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_name_too_long(self):
+        response = client.post(
+            "/categories/", json={"name": "가" * 51}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_name_stripped(self):
+        response = client.post(
+            "/categories/", json={"name": "  업무  "}, user=self.member
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["name"], "업무")
+
 
 class CategoryDetailTest(TestCase):
     def setUp(self):
@@ -102,6 +123,37 @@ class CategoryPatchTest(TestCase):
             user=self.member,
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_patch_null_name(self):
+        response = client.patch(
+            f"/categories/{self.category.id}/",
+            json={"name": None},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_empty_name(self):
+        response = client.patch(
+            f"/categories/{self.category.id}/",
+            json={"name": ""},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_name_too_long(self):
+        response = client.patch(
+            f"/categories/{self.category.id}/",
+            json={"name": "가" * 51},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_empty_body_keeps_name(self):
+        client.patch(
+            f"/categories/{self.category.id}/", json={}, user=self.member
+        )
+        self.category.refresh_from_db()
+        self.assertEqual(self.category.name, "업무")
 
     def test_patch_other_member(self):
         other = Member.objects.create_user(username="user2", password="pass")

--- a/todos/tests/test_todo_api.py
+++ b/todos/tests/test_todo_api.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.test import TestCase
 from ninja.testing import TestClient
 
@@ -31,6 +33,14 @@ class TodoListTest(TestCase):
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["status"], Todo.Status.DONE)
+
+    def test_list_invalid_status_filter(self):
+        response = client.get("/", user=self.member, query_params={"status": "bogus"})
+        self.assertEqual(response.status_code, 422)
+
+    def test_list_includes_due_date(self):
+        response = client.get("/", user=self.member)
+        self.assertIn("due_date", response.json()[0])
 
 
 class TodoCreateTest(TestCase):
@@ -66,6 +76,67 @@ class TodoCreateTest(TestCase):
             user=self.member,
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_create_empty_title(self):
+        response = client.post("/", json={"title": ""}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_whitespace_title(self):
+        response = client.post("/", json={"title": "   "}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_null_title(self):
+        response = client.post("/", json={"title": None}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_title_too_long(self):
+        response = client.post("/", json={"title": "가" * 201}, user=self.member)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_title_stripped(self):
+        response = client.post("/", json={"title": "  할일  "}, user=self.member)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["title"], "할일")
+
+    def test_create_invalid_status(self):
+        response = client.post(
+            "/",
+            json={"title": "할일", "status": "bogus"},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_valid_status(self):
+        response = client.post(
+            "/",
+            json={"title": "할일", "status": Todo.Status.IN_PROGRESS},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["status"], Todo.Status.IN_PROGRESS)
+
+    def test_create_default_status(self):
+        response = client.post("/", json={"title": "할일"}, user=self.member)
+        self.assertEqual(response.json()["status"], Todo.Status.TODO)
+
+    def test_create_with_due_date(self):
+        response = client.post(
+            "/",
+            json={"title": "할일", "due_date": date(2026, 12, 25)},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            Todo.objects.get(id=response.json()["id"]).due_date, date(2026, 12, 25)
+        )
+
+    def test_create_invalid_due_date(self):
+        response = client.post(
+            "/",
+            json={"title": "할일", "due_date": "not-a-date"},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
 
 
 class TodoDetailTest(TestCase):
@@ -123,6 +194,39 @@ class TodoUpdateTest(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_update_with_due_date(self):
+        response = client.put(
+            f"/{self.todo.id}/",
+            json={"title": "수정됨", "due_date": date(2026, 12, 25)},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.todo.refresh_from_db()
+        self.assertEqual(self.todo.due_date, date(2026, 12, 25))
+
+    def test_update_clears_due_date_when_omitted(self):
+        self.todo.due_date = date(2026, 12, 25)
+        self.todo.save()
+        client.put(f"/{self.todo.id}/", json={"title": "수정됨"}, user=self.member)
+        self.todo.refresh_from_db()
+        self.assertIsNone(self.todo.due_date)
+
+    def test_update_invalid_status(self):
+        response = client.put(
+            f"/{self.todo.id}/",
+            json={"title": "수정됨", "status": "bogus"},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_update_empty_title(self):
+        response = client.put(
+            f"/{self.todo.id}/",
+            json={"title": ""},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 422)
+
 
 class TodoPatchTest(TestCase):
     def setUp(self):
@@ -167,6 +271,82 @@ class TodoPatchTest(TestCase):
             user=self.member,
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_patch_null_title(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"title": None}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_null_description(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"description": None}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_null_status(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"status": None}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_empty_title(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"title": ""}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_title_too_long(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"title": "가" * 201}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_invalid_status(self):
+        response = client.patch(
+            f"/{self.todo.id}/", json={"status": "bogus"}, user=self.member
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_status(self):
+        response = client.patch(
+            f"/{self.todo.id}/",
+            json={"status": Todo.Status.DONE},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.todo.refresh_from_db()
+        self.assertEqual(self.todo.status, Todo.Status.DONE)
+
+    def test_patch_due_date(self):
+        response = client.patch(
+            f"/{self.todo.id}/",
+            json={"due_date": date(2026, 12, 25)},
+            user=self.member,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.todo.refresh_from_db()
+        self.assertEqual(self.todo.due_date, date(2026, 12, 25))
+
+    def test_patch_null_due_date_clears(self):
+        self.todo.due_date = date(2026, 12, 25)
+        self.todo.save()
+        client.patch(f"/{self.todo.id}/", json={"due_date": None}, user=self.member)
+        self.todo.refresh_from_db()
+        self.assertIsNone(self.todo.due_date)
+
+    def test_patch_null_category_clears(self):
+        category = Category.objects.create(member=self.member, name="업무")
+        self.todo.category = category
+        self.todo.save()
+        client.patch(f"/{self.todo.id}/", json={"category": None}, user=self.member)
+        self.todo.refresh_from_db()
+        self.assertIsNone(self.todo.category_id)
+
+    def test_patch_empty_body_keeps_fields(self):
+        client.patch(f"/{self.todo.id}/", json={}, user=self.member)
+        self.todo.refresh_from_db()
+        self.assertEqual(self.todo.title, "할일")
 
 
 class TodoDeleteTest(TestCase):

--- a/yorisa/api.py
+++ b/yorisa/api.py
@@ -1,0 +1,17 @@
+"""프로젝트 전역 API 조립 지점.
+
+각 앱은 `api.py`에서 `Router`만 export하고, `NinjaAPI` 인스턴스 생성과
+마운트는 이 파일에서만 수행한다. 앱 모듈은 이 파일을 import하지 않는다
+(순환 import 방지).
+"""
+
+from ninja import NinjaAPI
+
+from accounts.api import profile_router, router as auth_router
+from todos.api import router as todos_router
+
+api = NinjaAPI()
+
+api.add_router("/auth/", auth_router)
+api.add_router("/accounts/", profile_router)
+api.add_router("/todos/", todos_router)

--- a/yorisa/urls.py
+++ b/yorisa/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from django.shortcuts import render
 from django.urls import include, path
 
-from todos.api import api
+from yorisa.api import api
 
 
 def index(request):
@@ -27,9 +27,13 @@ def index(request):
 
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("accounts/", view=include("accounts.urls")),
+    # 서비스 진입점
     path("", index, name="index"),
+    # 관리자
+    path("admin/", admin.site.urls),
+    # REST API (django-ninja) — 라우터 마운트는 yorisa/api.py 참고
     path("api/", api.urls),
+    # 앱 템플릿 뷰
+    path("accounts/", include("accounts.urls")),
     path("todos/", include("todos.urls")),
 ]


### PR DESCRIPTION
### 설명

#### 구조 정리
- `NinjaAPI` 인스턴스 생성과 라우터 마운트를 `todos/api.py`에서 `yorisa/api.py`로 분리 (`refactor: API 조립 지점을 yorisa/api.py로 분리하고 루트 URL 정리`)
  - todos 앱이 `accounts.api`를 import하던 역방향 의존 제거 → `yorisa.api → {accounts.api, todos.api}` 단방향
  - 라우터 마운트 순서를 auth → accounts → todos로 맞춰 `docs/api.md` 목차와 일치
  - 루트 `urlpatterns`를 진입점 → 관리자 → API → 앱 뷰 순으로 정렬, `accounts`의 불필요한 `view=` 키워드 제거
- 위 변경에 맞춰 `CLAUDE.md` 갱신 (`docs: API 조립 구조 변경에 맞춰 CLAUDE.md 갱신`)

#### 스키마 검증 강화
`api.py`가 `full_clean()`을 호출하지 않아 스키마가 유일한 검증 지점인데, 제약을 하나도 반영하지 않던 문제를 수정합니다. (`fix: todos API 스키마가 모델 제약을 검증하도록 수정`)

- **길이·빈 문자열 검증 추가** — `title`(1~200자), Category `name`(1~50자). 앞뒤 공백 제거 후 검사해 템플릿 뷰의 `.strip()`과 동작 통일. 기존에는 `""`나 300자도 201로 저장됐고, PostgreSQL 전환 시 `DataError` 500이 될 상태였음
- **`status`를 `Todo.Status` TextChoices 타입으로 선언** — 규격 밖 값을 422로 거절. 목록 조회 `?status=` 쿼리 파라미터에도 동일 적용
- **PATCH 명시적 null → 500 수정** — NOT NULL 컬럼에서 `| None` 제거. `exclude_unset=True`는 *보내지 않은* 필드만 거를 뿐 *명시적으로 보낸 null*은 통과시켜 `PATCH {"title": null}`이 `IntegrityError`로 이어지던 문제. 실제 nullable인 `category`/`due_date`의 "null로 값 해제" 동작은 그대로 유지
- **`due_date` 추가** — 모델에만 있고 요청·응답 스키마 3개 모두에서 누락돼 있어 API로 기한일을 생성·수정·조회할 수 없었음
- 응답 스키마의 `status`는 `str`로 유지 — 규격 밖 값이 DB에 남아 있을 경우 응답 검증 실패로 목록 조회 전체가 500이 되는 것을 방지